### PR TITLE
ESLint improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,14 @@
     "ecmaVersion": 2018, // Allows for the parsing of modern ECMAScript features
     "sourceType": "module" // Allows for the use of imports
   },
+  "plugins": ["simple-import-sort"],
   "rules": {
+    // Auto-sort imports and exports
+    "simple-import-sort/imports": "error",
+		"simple-import-sort/exports": "error",
+		"sort-imports": "off",
+		"import/order": "off",
+
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
+  "editor.codeActionsOnSave": {
+		"source.fixAll.eslint": true
+	},
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^27.1.0",
     "jest-playwright": "^0.0.1",
     "jest-playwright-preset": "^1.4.5",

--- a/src/feature/react-hook-form/router.ts
+++ b/src/feature/react-hook-form/router.ts
@@ -1,4 +1,5 @@
 import * as trpc from '@trpc/server';
+
 import { validationSchema } from './index';
 
 const items = [

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,5 @@
+import '../styles/globals.css';
+
 import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
 import { loggerLink } from '@trpc/client/links/loggerLink';
 import { withTRPC } from '@trpc/next';
@@ -5,7 +7,6 @@ import { AppType } from 'next/dist/shared/lib/utils';
 import { useEffect, useState } from 'react';
 import { AppRouter } from 'server/routers/_app';
 import superjson from 'superjson';
-import '../styles/globals.css';
 
 function ContributorsWantedBanner() {
   const [visible, setVisible] = useState(false);

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -2,8 +2,8 @@
  * This file contains tRPC's HTTP response handler
  */
 import * as trpcNext from '@trpc/server/adapters/next';
-import { appRouter } from 'server/routers/_app';
 import { createContext } from 'server/context';
+import { appRouter } from 'server/routers/_app';
 
 export default trpcNext.createNextApiHandler({
   router: appRouter,

--- a/src/pages/ssg.tsx
+++ b/src/pages/ssg.tsx
@@ -1,11 +1,11 @@
 import { createSSGHelpers } from '@trpc/react/ssg';
-import { GetStaticPropsContext, InferGetStaticPropsType } from 'next';
+import { meta } from 'feature/ssg/meta';
+import { InferGetStaticPropsType } from 'next';
 import { createContext } from 'server/context';
 import { appRouter } from 'server/routers/_app';
 import superjson from 'superjson';
 import { ExamplePage } from 'utils/ExamplePage';
 import { trpc } from 'utils/trpc';
-import { meta } from 'feature/ssg/meta';
 
 export default function Page(
   props: InferGetStaticPropsType<typeof getStaticProps>,
@@ -26,7 +26,7 @@ export default function Page(
   );
 }
 
-export async function getStaticProps(context: GetStaticPropsContext) {
+export async function getStaticProps() {
   const ssg = createSSGHelpers({
     router: appRouter,
     ctx: await createContext(),

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,6 +1,5 @@
 import { PrismaClient } from '@prisma/client';
 import * as trpc from '@trpc/server';
-import * as trpcNext from '@trpc/server/adapters/next';
 
 const prisma = new PrismaClient({
   log:
@@ -8,13 +7,12 @@ const prisma = new PrismaClient({
       ? ['query', 'error', 'warn']
       : ['error'],
 });
+
 /**
  * Creates context for an incoming request
  * @link https://trpc.io/docs/context
  */
-export const createContext = async (
-  opts?: trpcNext.CreateNextContextOptions,
-) => {
+export const createContext = async () => {
   // for API-response caching see https://trpc.io/docs/caching
   return {
     prisma,

--- a/src/server/createRouter.ts
+++ b/src/server/createRouter.ts
@@ -1,4 +1,5 @@
 import * as trpc from '@trpc/server';
+
 import { Context } from './context';
 
 /**

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -4,6 +4,7 @@
 import { router as reactHookFormRouter } from 'feature/react-hook-form/router';
 import { router as ssgRouter } from 'feature/ssg/router';
 import superjson from 'superjson';
+
 import { createRouter } from '../createRouter';
 import { sourceRouter } from './source';
 

--- a/src/server/routers/source.ts
+++ b/src/server/routers/source.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
 import fs from 'fs';
-import { createRouter } from 'server/createRouter';
 import path from 'path';
+import { createRouter } from 'server/createRouter';
+import { z } from 'zod';
 export const sourceRouter = createRouter().query('getSource', {
   input: z.object({
     path: z.string().refine((val) => !val.includes('..'), {

--- a/src/utils/ClientSuspense.tsx
+++ b/src/utils/ClientSuspense.tsx
@@ -31,7 +31,7 @@ export class ErrorBoundary extends Component<Props, State> {
     hasError: false,
   };
 
-  public static getDerivedStateFromError(_: Error): State {
+  public static getDerivedStateFromError(): State {
     // Update state so the next render will show the fallback UI.
     return { hasError: true };
   }

--- a/src/utils/ExamplePage.tsx
+++ b/src/utils/ExamplePage.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { HomeIcon, ClipboardCopyIcon, CheckIcon } from '@heroicons/react/solid';
+import { EyeIcon } from '@heroicons/react/outline';
+import { CodeIcon } from '@heroicons/react/outline';
+import { CheckIcon, ClipboardCopyIcon, HomeIcon } from '@heroicons/react/solid';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import theme from 'prism-react-renderer/themes/vsDark';
 import { Fragment, ReactNode, useEffect } from 'react';
+
 import { ClientSuspense, ErrorBoundary } from './ClientSuspense';
 import { trpc } from './trpc';
-import { EyeIcon } from '@heroicons/react/outline';
-import { CodeIcon } from '@heroicons/react/outline';
 import { useClipboard } from './useClipboard';
 
 interface SourceFile {

--- a/src/utils/useClipboard.ts
+++ b/src/utils/useClipboard.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export const useClipboard = (text: string): [boolean, () => void] => {
   const [hasCopied, setHasCopied] = useState(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,6 +2494,11 @@ eslint-plugin-react@^7.23.1, eslint-plugin-react@^7.25.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
+eslint-plugin-simple-import-sort@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
+  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
Sorry for the big PR!

There’s two things here:

1. I added a rule to the VS Code settings so that it runs ESLint on save. This is convenient for anyone who doesn’t already have ESLint configured.
2. Feel free to discard this if you disagree, but I often find using import sorting quite helpful, both in keeping the code looking organised but especially to tell the difference between third party and local imports. I added an ESLint plugin that does this.

I also fixed a few lines that were throwing lint warnings.