### PR TITLE
convert getSession to the faster v4 getServerSession in next-auth 

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,7 +1,7 @@
-import NextAuth from 'next-auth';
+import NextAuth, { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 
-export default NextAuth({
+export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
       // The name to display on the sign in form (e.g. 'Sign in with...')
@@ -33,4 +33,6 @@ export default NextAuth({
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
-});
+};
+
+export default NextAuth(authOptions);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34382127/152050414-f7a7804b-e78a-413d-8cbf-0e062b93d882.png)

Converted `getSession` in tRPC context to `getServerSession`, a new next-auth v4 API that is dramatically more performant since it avoids an HTTP request to /api/auth. Also properly updates the session cookies.

This is particularly important as the session gathering is done for every request, which adds ~100-150ms of additional latency (US-East-1).


