### PR TITLE
fix: static props inference

### DIFF
--- a/src/feature/ssg/meta.tsx
+++ b/src/feature/ssg/meta.tsx
@@ -13,5 +13,6 @@ export const meta: ExampleProps = {
   files: [
     { title: 'Router', path: 'feature/ssg/router.ts' },
     { title: 'Page', path: 'pages/ssg.tsx' },
+    { title: 'Infer SSG Helper', path: 'utils/inferSSGProps.ts' },
   ],
 };

--- a/src/pages/ssg.tsx
+++ b/src/pages/ssg.tsx
@@ -1,14 +1,14 @@
 import { createSSGHelpers } from '@trpc/react/ssg';
 import { meta } from 'feature/ssg/meta';
-import { InferGetStaticPropsType } from 'next';
 import { createContext } from 'server/context';
 import { appRouter } from 'server/routers/_app';
 import superjson from 'superjson';
 import { ExamplePage } from 'utils/ExamplePage';
+import { inferSSGProps } from 'utils/inferSSGProps';
 import { trpc } from 'utils/trpc';
 
 export default function Page(
-  props: InferGetStaticPropsType<typeof getStaticProps>,
+  props: inferSSGProps<typeof getStaticProps>,
 ) {
   const { id } = props;
   const query = trpc.useQuery(['ssg.byId', { id }]);

--- a/src/pages/ssg.tsx
+++ b/src/pages/ssg.tsx
@@ -7,9 +7,7 @@ import { ExamplePage } from 'utils/ExamplePage';
 import { inferSSGProps } from 'utils/inferSSGProps';
 import { trpc } from 'utils/trpc';
 
-export default function Page(
-  props: inferSSGProps<typeof getStaticProps>,
-) {
+export default function Page(props: inferSSGProps<typeof getStaticProps>) {
   const { id } = props;
   const query = trpc.useQuery(['ssg.byId', { id }]);
 

--- a/src/utils/inferSSGProps.ts
+++ b/src/utils/inferSSGProps.ts
@@ -1,0 +1,15 @@
+// https://github.com/vercel/next.js/issues/15913#issuecomment-911684434
+type GetSSGResult<TProps> =
+  | { props: TProps }
+  | { redirect: any }
+  | { notFound: boolean };
+
+type GetSSGFn<TProps extends any> = (
+  args: any,
+) => Promise<GetSSGResult<TProps>>;
+
+export type inferSSGProps<TFn extends GetSSGFn<any>> = TFn extends GetSSGFn<
+  infer TProps
+>
+  ? NonNullable<TProps>
+  : never;


### PR DESCRIPTION
### Description
Example was not inferring static props and resulting in `never`

Found this gem buried in an issue and applied the same solution here
https://github.com/vercel/next.js/issues/15913#issuecomment-911684434


<img width="1298" alt="image" src="https://user-images.githubusercontent.com/3660667/174504600-7de1fb26-731d-4880-b32b-d1f9d917ade7.png">
