### PR TITLE
remove private input reference from react-hook-form example

### DIFF
--- a/src/feature/react-hook-form/index.tsx
+++ b/src/feature/react-hook-form/index.tsx
@@ -10,11 +10,11 @@ export const validationSchema = z.object({
 });
 
 function useZodForm<TSchema extends z.ZodType>(
-  props: Omit<UseFormProps<TSchema['_input']>, 'resolver'> & {
+  props: Omit<UseFormProps<z.infer<TSchema>>, 'resolver'> & {
     schema: TSchema;
   },
 ) {
-  const form = useForm<TSchema['_input']>({
+  const form = useForm<z.infer<TSchema>>({
     ...props,
     resolver: zodResolver(props.schema, undefined),
   });


### PR DESCRIPTION
I am ~70% sure this has the same effect, and avoids the need to reference a private field. I am quite new to all this tech, so please forgive me if this PR is out of whack – appreciation for any guidance & attention towards this issue!!

See also git@github.com:jdevries3133/examples-kitchen-sink.git